### PR TITLE
Add feature to use system fonts

### DIFF
--- a/src/_locales/en/messages.json
+++ b/src/_locales/en/messages.json
@@ -44,6 +44,7 @@
   "css_round_pic": { "message": "Rounded avatars" },
   "css_bigger_emojis": { "message": "Bigger emojis in tweets" },
   "css_collapse_dms": { "message": "Collapse read direct messages" },
+  "css_system_fonts": { "message": "Use the system font in the UI" },
   "css_show_verified": { "message": "Show 'verified' badges on top of avatars" },
   "css_hide_context": { "message": "Hide 'In reply to' label on mentions" },
   "css_actions_on_right": { "message": "Show tweet actions on the right" },

--- a/src/css/features/system-fonts.css
+++ b/src/css/features/system-fonts.css
@@ -1,0 +1,3 @@
+.btd__system_fonts {
+  font-family: -apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,Oxygen-Sans,Ubuntu,Cantarell,"Helvetica Neue",sans-serif;
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -21,6 +21,7 @@
 @import './features/slim_scrollbars.css';
 @import './features/username-typeahead.css';
 @import './features/stars.css';
+@import './features/system-fonts.css';
 @import './features/show-provider-name.css';
 @import './features/hide-like-rt-indicators.css';
 

--- a/src/js/background.js
+++ b/src/js/background.js
@@ -44,6 +44,7 @@ const defaultSettings = {
     no_bg_modal: true,
     show_provider_indicator: false,
     hide_like_rt_indicators: false,
+    system_fonts: false,
   },
   share_item: {
     enabled: true,

--- a/src/options/options.html
+++ b/src/options/options.html
@@ -291,6 +291,10 @@
             <label for="collapse_dms" data-lang="css_collapse_dms" data-new-feat >Collapse read direct messages</label>
           </li>
           <li>
+            <input type="checkbox" name="css.system_fonts" id="system_fonts">
+            <label for="system_fonts" data-lang="css_system_fonts" data-new-feat >Use the system font in the UI</label>
+          </li>
+          <li>
             <input type="checkbox" name="custom_columns_width.enabled" id="column_width" data-ghost><label for="column_width" data-lang="custom_width_columns" data-new-feat>Custom width for columns:</label>
             <ul>
               <li>


### PR DESCRIPTION
This PR adds a new toggle which changes the UI font to a system font stack, covering a multitude of different operating system fonts.

This is thought off as a compromise to #38, to have a set of cleaner fonts at hand.